### PR TITLE
Add status context property

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.1
+
+* Add context parameter to github.add_status action
+
 ## v0.6.0
 
 * Add deployment event webhook.

--- a/actions/add_status.py
+++ b/actions/add_status.py
@@ -8,14 +8,15 @@ __all__ = [
 
 
 class AddCommitStatusAction(BaseGithubAction):
-    def run(self, user, repo, sha, state, target_url=None, description=None):
+    def run(self, user, repo, sha, state, target_url=None, description=None, context=None):
         target_url = target_url or GithubObject.NotSet
         description = description or GithubObject.NotSet
+        context = context or GithubObject.NotSet
 
         user = self._client.get_user(user)
         repo = user.get_repo(repo)
         commit = repo.get_commit(sha)
 
         commit.create_status(state=state, target_url=target_url,
-                             description=description)
+                             description=description, context=context)
         return True

--- a/actions/add_status.yaml
+++ b/actions/add_status.yaml
@@ -29,3 +29,7 @@
       type: "string"
       description: "A short description of the status."
       required: false
+    context:
+      type: "string"
+      description: "A string label to differentiate this status from the status of other systems. Default: \"default\""
+      required: false

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - github
   - git
   - scm
-version : 0.6.0
+version : 0.6.1
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
The context property allows github to differentiate between statuses coming from different external systems. Not being able to set context severely limits action use.