### PR TITLE
Remove immutable from deploy_payload from github.deployment_event

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.6.2
+
+* Remove `immutable: true` from deploy_payload the parameter in
+  deployment_event action.
+
 ## v0.6.1
 
 * Add context parameter to github.add_status action

--- a/actions/deployment_event.yaml
+++ b/actions/deployment_event.yaml
@@ -47,4 +47,3 @@ parameters:
     type: "string"
     description: "Additional payload information from GitHub"
     default: "{}"
-    immutable: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,8 @@ keywords:
   - github
   - git
   - scm
-version : 0.6.1
+version : 0.6.2
 author : StackStorm, Inc.
 email : info@stackstorm.com
+contributors:
+  - Jon Middleton <jon.middleton@pulsant.com>


### PR DESCRIPTION
The immutable flag is prevents successful deployments of packs via deployment events from GitHub (Fixes: #3).