### PR TITLE
Update the deployment_event workflow to use packs.install 2.1+ parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.3
+
+* Update the parameters for `pack.install` as they have changed.
+
 ## v0.6.2
 
 * Remove `immutable: true` from deploy_payload the parameter in

--- a/README.md
+++ b/README.md
@@ -122,4 +122,4 @@ command:
 - It only works for the default `github_type`.
 - If using with GitHub.com you your ST2 server needs to be contactable via the internet!
 - Deployment Statuses will be logged as the creating user in GitHub.
-- You can't currently deploy tags, due to a limitation in `packs.download`.
+- With StackStorm v2.1+ you should be able to deploy tags.

--- a/actions/workflows/deployment_event.yaml
+++ b/actions/workflows/deployment_event.yaml
@@ -33,10 +33,7 @@ github.deployment_event:
       action: packs.install
 
       input:
-        packs: [  <% $.repo_name %> ]
-        repo_url: <% $.ssh_url %>
-        branch: <% $.deploy_ref %>
-        subtree: false
+        packs: [  "<% $.ssh_url %>=<% $.deploy_ref %>" ]
 
       on-success:
         - deployment_successful

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - github
   - git
   - scm
-version : 0.6.2
+version : 0.6.3
 author : StackStorm, Inc.
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
Some fixes, as triggering pack deployments from GitHub is not currently function:

- Update parameters for packs.install in `deployment_event` workflow (Fixes: #7).
- Update comment in README that tags now work in ST2 2.1+
- Bump the version number.
