### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.0
+
+* Updated action `runner_type` from `run-python` to `python-script`
+
 ## v0.6.3
 
 * Update the parameters for `pack.install` as they have changed.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Keep in mind that even thought actions which operate on public repositories
 don't require authentication token you are still encouraged to supply one
 because unauthenticated requests have a very low rate limit.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Obtaining Authentication Token
 
 To obtain authentication token, follow the instructions on the [Creating an

--- a/actions/add_comment.yaml
+++ b/actions/add_comment.yaml
@@ -1,6 +1,6 @@
 ---
   name: "add_comment"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Add a comment to the provided issue / pull request."
   enabled: true
   entry_point: "add_comment.py"

--- a/actions/add_status.yaml
+++ b/actions/add_status.yaml
@@ -1,6 +1,6 @@
 ---
   name: "add_status"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Add a commit status for a provided ref."
   enabled: true
   entry_point: "add_status.py"

--- a/actions/add_team_membership.yaml
+++ b/actions/add_team_membership.yaml
@@ -1,6 +1,6 @@
 ---
 name: add_team_membership
-runner_type: run-python
+runner_type: python-script
 description: Add (and invite if not a member) a user to a team
 enabled: true
 entry_point: add_team_membership.py

--- a/actions/check_deployment_env.yaml
+++ b/actions/check_deployment_env.yaml
@@ -1,6 +1,6 @@
 ---
 name: "check_deployment_env"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Check if deployment event applies to this server."
 enabled: true
 entry_point: "check_deployment_env.py"

--- a/actions/create_deployment.yaml
+++ b/actions/create_deployment.yaml
@@ -1,6 +1,6 @@
 ---
 name: "create_deployment"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Create a new deployment for a GitHub repository"
 enabled: true
 entry_point: "create_deployment.py"

--- a/actions/create_deployment_status.yaml
+++ b/actions/create_deployment_status.yaml
@@ -1,6 +1,6 @@
 ---
 name: "create_deployment_status"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Create a new deployment Status for a GitHub repository"
 enabled: true
 entry_point: "create_deployment_status.py"

--- a/actions/create_issue.yaml
+++ b/actions/create_issue.yaml
@@ -1,6 +1,6 @@
 ---
 name: create_issue
-runner_type: run-python
+runner_type: python-script
 description: Create a Github issue.
 enabled: true
 entry_point: create_issue.py

--- a/actions/create_release.yaml
+++ b/actions/create_release.yaml
@@ -1,6 +1,6 @@
 ---
 name: "create_release"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Create a new release for a GitHub repository"
 enabled: true
 entry_point: "create_release.py"

--- a/actions/get_clone_stats.yaml
+++ b/actions/get_clone_stats.yaml
@@ -1,6 +1,6 @@
 ---
 name: get_clone_stats
-runner_type: run-python
+runner_type: python-script
 description: Retrieve clone statistics for a given repository
 enabled: true
 entry_point: get_clone_stats.py

--- a/actions/get_deployment_statuses.yaml
+++ b/actions/get_deployment_statuses.yaml
@@ -1,6 +1,6 @@
 ---
 name: "get_deployment_statuses"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Get the statuses of a deployment for a GitHub repository"
 enabled: true
 entry_point: "get_deployment_statuses.py"

--- a/actions/get_issue.yaml
+++ b/actions/get_issue.yaml
@@ -1,6 +1,6 @@
 ---
 name: get_issue
-runner_type: run-python
+runner_type: python-script
 description: Retrieve information about a particular Github issue.
 enabled: true
 entry_point: get_issue.py

--- a/actions/get_traffic_stats.yaml
+++ b/actions/get_traffic_stats.yaml
@@ -1,6 +1,6 @@
 ---
 name: get_traffic_stats
-runner_type: run-python
+runner_type: python-script
 description: Retrieve traffic statistics for a given repository
 enabled: true
 entry_point: get_traffic_stats.py

--- a/actions/get_user.yaml
+++ b/actions/get_user.yaml
@@ -1,6 +1,6 @@
 ---
 name: get_user
-runner_type: run-python
+runner_type: python-script
 description: Get a user from the Github user database
 enabled: true
 entry_point: get_user.py

--- a/actions/latest_release.yaml
+++ b/actions/latest_release.yaml
@@ -1,6 +1,6 @@
 ---
 name: "latest_release"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "List the latest release for a GitHub repository"
 enabled: true
 entry_point: "latest_release.py"

--- a/actions/list_deployments.yaml
+++ b/actions/list_deployments.yaml
@@ -1,6 +1,6 @@
 ---
 name: "list_deployments"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "List deployments for a GitHub repository"
 enabled: true
 entry_point: "list_deployments.py"

--- a/actions/list_issues.yaml
+++ b/actions/list_issues.yaml
@@ -1,6 +1,6 @@
 ---
 name: list_issues
-runner_type: run-python
+runner_type: python-script
 description: Retrieve a list of issues (including pull requests) for a particular repository.
 enabled: true
 entry_point: list_issues.py

--- a/actions/list_releases.yaml
+++ b/actions/list_releases.yaml
@@ -1,6 +1,6 @@
 ---
 name: "list_releases"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "List releases for a GitHub repository"
 enabled: true
 entry_point: "list_releases.py"

--- a/actions/list_teams.yaml
+++ b/actions/list_teams.yaml
@@ -1,6 +1,6 @@
 ---
 name: list_teams
-runner_type: run-python
+runner_type: python-script
 description: List teams in organization
 enabled: true
 entry_point: list_teams.py

--- a/actions/store_oauth_token.yaml
+++ b/actions/store_oauth_token.yaml
@@ -1,6 +1,6 @@
 ---
 name: "store_oauth_token"
-runner_type: "run-python"
+runner_type: "python-script"
 description: "Store a users GitHub OAuth token."
 enabled: true
 entry_point: "store_oauth_token.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - github
   - git
   - scm
-version : 0.6.3
+version : 0.7.0
 author : StackStorm, Inc.
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.