### PR TITLE
Make repository_sensor optional

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.1
+
+* Make `repository_sensor` section in config schema optional 
+
 ## 0.8.0
 
 * Added missing repository\_sensor section to `config.schema.yaml`

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -41,7 +41,7 @@ deployment_environment:
 repository_sensor:
   description: "Sensor specific settings."
   type: "object"
-  required: true
+  required: false
   additionalProperties: false
   properties:
     event_type_whitelist:

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - github
   - git
   - scm
-version : 0.8.0
+version : 0.8.1
 author : StackStorm, Inc.
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
Users should be able to use Github pack without configuring `repository_sensor` in config.
Entire Sensor functionality shall be optional.