### PR TITLE
Prevent tokens with whitespace causing authentication failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.8.2
+
+* Strip whitespace from tokens when being stored by a user (Fixes: #14).
+
 ## 0.8.1
 
 * Make `repository_sensor` section in config schema optional 

--- a/actions/store_oauth_token.py
+++ b/actions/store_oauth_token.py
@@ -28,6 +28,6 @@ class StoreOauthTokenAction(BaseGithubAction):
 
         self.action_service.set_value(
             name=value_name,
-            value=token)
+            value=token.strip())
 
         return results

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,9 +4,10 @@ name : github
 description : GitHub integration
 keywords:
   - github
+  - github enterprise
   - git
   - scm
-version : 0.8.1
+version : 0.8.2
 author : StackStorm, Inc.
 email : info@stackstorm.com
 contributors:

--- a/tests/github_base_action_test_case.py
+++ b/tests/github_base_action_test_case.py
@@ -40,6 +40,10 @@ class GitHubBaseActionTestCase(BaseActionTestCase):
     def full_config(self):
         return self._full_config
 
+    @property
+    def enterprise_config(self):
+        return self._enterprise_default_config
+
     def test_run_no_config(self):
         action = self.get_action_instance(self.full_config)
         self.assertIsInstance(action, self.action_cls)

--- a/tests/test_action_store_oauth_token.py
+++ b/tests/test_action_store_oauth_token.py
@@ -23,13 +23,13 @@ class StoreOauthTokenActionTestCase(GitHubBaseActionTestCase):
     __test__ = True
     action_cls = StoreOauthTokenAction
 
-    def test_run_uses_public(self):
+    def test_run_uses_online(self):
         expected = {'github_type': "online"}
         action = self.get_action_instance(self.enterprise_config)
 
         results = action.run(user="octocat",
                              token="foo",
-                             github_type="public")
+                             github_type="online")
 
         self.assertEqual(results, expected)
         self.assertEqual("foo",

--- a/tests/test_action_store_oauth_token.py
+++ b/tests/test_action_store_oauth_token.py
@@ -46,3 +46,30 @@ class StoreOauthTokenActionTestCase(GitHubBaseActionTestCase):
         self.assertEqual(results, expected)
         self.assertEqual("foo",
                          action.action_service.get_value("token_enterprise_octocat"))
+
+    def test_run_token_string_whitespace_start(self):
+        action = self.get_action_instance(self.full_config)
+
+        results = action.run(user="octocat",
+                             token=" foo")
+
+        self.assertEqual("foo",
+                         action.action_service.get_value("token_octocat"))
+
+    def test_run_token_string_whitespace_end(self):
+        action = self.get_action_instance(self.full_config)
+
+        results = action.run(user="octocat",
+                             token="foo ")
+
+        self.assertEqual("foo",
+                         action.action_service.get_value("token_octocat"))
+
+    def test_run_token_string_whitespace_both(self):
+        action = self.get_action_instance(self.full_config)
+
+        results = action.run(user="octocat",
+                             token=" foo ")
+
+        self.assertEqual("foo",
+                         action.action_service.get_value("token_octocat"))

--- a/tests/test_action_store_oauth_token.py
+++ b/tests/test_action_store_oauth_token.py
@@ -52,7 +52,8 @@ class StoreOauthTokenActionTestCase(GitHubBaseActionTestCase):
         action = self.get_action_instance(self.full_config)
 
         results = action.run(user="octocat",
-                             token=" foo")
+                             token=" foo",
+                             github_type="online")
 
         self.assertEqual(results, expected)
         self.assertEqual("foo",
@@ -63,7 +64,8 @@ class StoreOauthTokenActionTestCase(GitHubBaseActionTestCase):
         action = self.get_action_instance(self.full_config)
 
         results = action.run(user="octocat",
-                             token="foo ")
+                             token="foo ",
+                             github_type="online")
 
         self.assertEqual(results, expected)
         self.assertEqual("foo",
@@ -74,7 +76,8 @@ class StoreOauthTokenActionTestCase(GitHubBaseActionTestCase):
         action = self.get_action_instance(self.full_config)
 
         results = action.run(user="octocat",
-                             token=" foo ")
+                             token=" foo ",
+                             github_type="online")
 
         self.assertEqual(results, expected)
         self.assertEqual("foo",

--- a/tests/test_action_store_oauth_token.py
+++ b/tests/test_action_store_oauth_token.py
@@ -48,28 +48,34 @@ class StoreOauthTokenActionTestCase(GitHubBaseActionTestCase):
                          action.action_service.get_value("token_enterprise_octocat"))
 
     def test_run_token_string_whitespace_start(self):
+        expected = {'github_type': "online"}
         action = self.get_action_instance(self.full_config)
 
         results = action.run(user="octocat",
                              token=" foo")
 
+        self.assertEqual(results, expected)
         self.assertEqual("foo",
                          action.action_service.get_value("token_octocat"))
 
     def test_run_token_string_whitespace_end(self):
+        expected = {'github_type': "online"}
         action = self.get_action_instance(self.full_config)
 
         results = action.run(user="octocat",
                              token="foo ")
 
+        self.assertEqual(results, expected)
         self.assertEqual("foo",
                          action.action_service.get_value("token_octocat"))
 
     def test_run_token_string_whitespace_both(self):
+        expected = {'github_type': "online"}
         action = self.get_action_instance(self.full_config)
 
         results = action.run(user="octocat",
                              token=" foo ")
 
+        self.assertEqual(results, expected)
         self.assertEqual("foo",
                          action.action_service.get_value("token_octocat"))

--- a/tests/test_action_store_oauth_token.py
+++ b/tests/test_action_store_oauth_token.py
@@ -24,15 +24,25 @@ class StoreOauthTokenActionTestCase(GitHubBaseActionTestCase):
     action_cls = StoreOauthTokenAction
 
     def test_run_uses_public(self):
+        expected = {'github_type': "online"}
         action = self.get_action_instance(self.enterprise_config)
 
-        results = action.run(user="octocat", github_type="public")
-        expected = {'github_type': "online"}
+        results = action.run(user="octocat",
+                             token="foo"
+                             github_type="public")
+
         self.assertEqual(results, expected)
+        self.assertEqual("foo",
+                         action.action_service.get_value("token_octocat"))
 
     def test_run_uses_enterprise(self):
+        expected = {'github_type': "enterprise"}
         action = self.get_action_instance(self.enterprise_config)
 
-        results = action.run(user="octocat", github_type="enterprise")
-        expected = {'github_type': "enterprise"}
+        results = action.run(user="octocat",
+                             token="foo"
+                             github_type="enterprise")
+
         self.assertEqual(results, expected)
+        self.assertEqual("foo",
+                         action.action_service.get_value("token_enterprise_octocat"))

--- a/tests/test_action_store_oauth_token.py
+++ b/tests/test_action_store_oauth_token.py
@@ -28,7 +28,7 @@ class StoreOauthTokenActionTestCase(GitHubBaseActionTestCase):
         action = self.get_action_instance(self.enterprise_config)
 
         results = action.run(user="octocat",
-                             token="foo"
+                             token="foo",
                              github_type="public")
 
         self.assertEqual(results, expected)
@@ -40,7 +40,7 @@ class StoreOauthTokenActionTestCase(GitHubBaseActionTestCase):
         action = self.get_action_instance(self.enterprise_config)
 
         results = action.run(user="octocat",
-                             token="foo"
+                             token="foo",
                              github_type="enterprise")
 
         self.assertEqual(results, expected)

--- a/tests/test_action_store_oauth_token.py
+++ b/tests/test_action_store_oauth_token.py
@@ -22,3 +22,17 @@ from store_oauth_token import StoreOauthTokenAction
 class StoreOauthTokenActionTestCase(GitHubBaseActionTestCase):
     __test__ = True
     action_cls = StoreOauthTokenAction
+
+    def test_run_uses_public(self):
+        action = self.get_action_instance(self.enterprise_config)
+
+        results = action.run(user="octocat", github_type="public")
+        expected = {'github_type': "online"}
+        self.assertEqual(results, expected)
+
+    def test_run_uses_enterprise(self):
+        action = self.get_action_instance(self.enterprise_config)
+
+        results = action.run(user="octocat", github_type="enterprise")
+        expected = {'github_type': "enterprise"}
+        self.assertEqual(results, expected)


### PR DESCRIPTION
Improve testing and correct whitespace issues:

- Add unit tests for action store_oauth_token.
- Strip whitespace from token when storing (Fixes: #14).
- Bump version to `v0.8.2`
