### PR TITLE
Fix misleading config param github_url/base_url

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+
+## 1.0.0
+
+* Clean up `enterprise_url` params, fixing github enterprise support
+
 ## 0.8.4
 
 * Version bump to fix tagging issues, no code changes
@@ -14,7 +19,7 @@
 
 ## 0.8.1
 
-* Make `repository_sensor` section in config schema optional 
+* Make `repository_sensor` section in config schema optional
 
 ## 0.8.0
 
@@ -23,7 +28,7 @@
 
 ## 0.7.1
 
-* Update sensor to use ``base_url`` option. 
+* Update sensor to use ``base_url`` option.
 
 ## 0.7.0
 
@@ -54,7 +59,7 @@
 * Migrate config.yaml to config.schema.yaml.
 * Add actions and aliases managing releases (list, create, latest).
 * Add actions and aliases for managing deployments.
-* Add action and aliases for sorting a user scoped GitHub oauth token 
+* Add action and aliases for sorting a user scoped GitHub oauth token
   for GitHub.com and GitHub Enterprise.
 
 ## v0.4.0

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Currently supported event types:
 * ``ReleaseEvent`` - Triggered when new release is available.
 * ``PushEvent`` - Triggered when a repository branch is pushed to. In addition to branch pushes, webhook push events are also triggered when repository tags are pushed.
 
+**Note** : The sensor will only listen events for the `github_type` you chosen
+           in config.yaml
+
+
 #### github.repository_event trigger
 
 Example trigger payload:
@@ -131,7 +135,6 @@ command:
 ### Limitations
 
 - You need to have logged an OAuth key with StackStorm (via `github.store_oauth_token`).
-- It only works for the default `github_type`.
 - If using with GitHub.com your ST2 server needs to be contactable via the internet!
 - Deployment Statuses will be logged as the creating user in GitHub.
 - With StackStorm v2.1+ you should be able to deploy tags.

--- a/actions/get_clone_stats.py
+++ b/actions/get_clone_stats.py
@@ -7,5 +7,6 @@ __all__ = [
 
 class GetCloneStatsAction(BaseGithubAction):
     def run(self, repo):
-        clone_data = self._get_analytics(category='clone-activity-data', repo=repo)
+        enterprise = self._is_enterprise(github_type)
+        clone_data = self._get_analytics(category='clone-activity-data', repo=repo, enterprise)
         return clone_data['summary']

--- a/actions/get_clone_stats.py
+++ b/actions/get_clone_stats.py
@@ -6,7 +6,7 @@ __all__ = [
 
 
 class GetCloneStatsAction(BaseGithubAction):
-    def run(self, repo):
-        enterprise = self._is_enterprise(github_type)
-        clone_data = self._get_analytics(category='clone-activity-data', repo=repo, enterprise)
+    def run(self, repo, github_type):
+        clone_data = self._get_analytics(
+            category='clone-activity-data', repo=repo, enterprise=self._is_enterprise(github_type))
         return clone_data['summary']

--- a/actions/get_clone_stats.yaml
+++ b/actions/get_clone_stats.yaml
@@ -9,3 +9,7 @@ parameters:
     type: string
     description: "Repository to query for clone stats (org/repo)"
     required: true
+  github_type:
+    type: "string"
+    description: "The type of github installation to target, if unset will use the configured default."
+    default: ~

--- a/actions/get_traffic_stats.py
+++ b/actions/get_traffic_stats.py
@@ -6,7 +6,7 @@ __all__ = [
 
 
 class GetTrafficStatsAction(BaseGithubAction):
-    def run(self, repo):
-        enterprise = self._is_enterprise(github_type)
-        traffic_data = self._get_analytics(category='traffic-data', repo=repo, enterprise)
+    def run(self, repo, github_type):
+        traffic_data = self._get_analytics(
+            category='traffic-data', repo=repo, enterprise=self._is_enterprise(github_type))
         return traffic_data['summary']

--- a/actions/get_traffic_stats.py
+++ b/actions/get_traffic_stats.py
@@ -7,5 +7,6 @@ __all__ = [
 
 class GetTrafficStatsAction(BaseGithubAction):
     def run(self, repo):
-        traffic_data = self._get_analytics(category='traffic-data', repo=repo)
+        enterprise = self._is_enterprise(github_type)
+        traffic_data = self._get_analytics(category='traffic-data', repo=repo, enterprise)
         return traffic_data['summary']

--- a/actions/get_traffic_stats.yaml
+++ b/actions/get_traffic_stats.yaml
@@ -9,3 +9,7 @@ parameters:
     type: string
     description: "Repository to query for traffic stats (org/repo)"
     required: true
+  github_type:
+    type: "string"
+    description: "The type of github installation to target, if unset will use the configured default."
+    default: ~

--- a/actions/get_user.py
+++ b/actions/get_user.py
@@ -7,9 +7,10 @@ __all__ = [
 
 
 class GetUserAction(BaseGithubAction):
-    def run(self, user, token_user):
+    def run(self, user, token_user, github_type):
+        enterprise = self._is_enterprise(github_type)
         if token_user:
-            self._change_to_user_token(token_user)
+            self._change_to_user_token(token_user, enterprise)
 
         user = self._client.get_user(user)
         result = user_to_dict(user=user)

--- a/actions/get_user.yaml
+++ b/actions/get_user.yaml
@@ -13,3 +13,7 @@ parameters:
     type: "string"
     description: "The"
     default: "{{action_context.api_user|default(None)}}"
+  github_type:
+    type: "string"
+    description: "The type of github installation to target, if unset will use the configured default."
+    default: ~

--- a/actions/lib/base.py
+++ b/actions/lib/base.py
@@ -22,11 +22,12 @@ class BaseGithubAction(Action):
         super(BaseGithubAction, self).__init__(config=config)
         token = self.config.get('token', None)
         self.token = token or None
-        self.github_url = self.config.get('github_url', DEFAULT_API_URL)
-        self.enterprise_url = self.config.get('enterprise_url', None)
+        self.web_url = self.config.get('web_url', DEFAULT_WEB_URL)
+        self.base_url = self.config.get('base_url', DEFAULT_API_URL)
+
         self.default_github_type = self.config.get('github_type', None)
 
-        self._client = Github(self.token, base_url=self.github_url)
+        self._client = Github(self.token, base_url=self.base_url)
         self._session = requests.Session()
 
     def _web_session(self):

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -22,15 +22,17 @@ github_type:
     - "enterprise"
   required: true
 
+web_url:
+  description: "The GitHub URL."
+  type: "string"
+  default: "https://github.com"
+  required: true
+
 base_url:
-  description: "The GitHub URL, for GitHub Enterprise please set enterprise_url."
+  description: "GitHub API url, include /api/v3 for GitHub Enterprise."
   type: "string"
   default: "https://api.github.com"
   required: true
-
-enterprise_url:
-  description: "GitHub API url (including /api/v3) of your GitHub Enterprise hostname."
-  type: "string"
 
 deployment_environment:
   description: "The environment for this StackStorm server."

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -29,7 +29,7 @@ web_url:
   required: false
 
 base_url:
-    description: "GitHub API url, include /api/v3 for GitHub Enterprise. exp: "
+  description: "GitHub API url, include /api/v3 for GitHub Enterprise. exp: "
   type: "string"
   default: "https://github.example.com/api/v3"
   required: false
@@ -41,7 +41,7 @@ deployment_environment:
   default: "production"
 
 repository_sensor:
-  description: "Sensor specific settings."
+  description: "Sensor specific settings, with default github type."
   type: "object"
   required: false
   additionalProperties: false

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -25,14 +25,14 @@ github_type:
 web_url:
   description: "The GitHub URL."
   type: "string"
-  default: "https://github.com"
-  required: true
+  default: "https://github.example.com"
+  required: false
 
 base_url:
-  description: "GitHub API url, include /api/v3 for GitHub Enterprise."
+    description: "GitHub API url, include /api/v3 for GitHub Enterprise. exp: "
   type: "string"
-  default: "https://api.github.com"
-  required: true
+  default: "https://github.example.com/api/v3"
+  required: false
 
 deployment_environment:
   description: "The environment for this StackStorm server."

--- a/github.yaml.example
+++ b/github.yaml.example
@@ -3,8 +3,8 @@ token: "{{system.github_oauth_token}}"
 user: "Stanley"
 password: "P4ssw0rd"
 github_type: "online"
+web_url: "https://github.com"
 base_url: "https://api.github.com"
-enterprise_url: ""
 deployment_environment: "production"
 repository_sensor:
   event_type_whitelist:

--- a/github.yaml.example
+++ b/github.yaml.example
@@ -3,8 +3,8 @@ token: "{{system.github_oauth_token}}"
 user: "Stanley"
 password: "P4ssw0rd"
 github_type: "online"
-web_url: "https://github.com"
-base_url: "https://api.github.com"
+web_url: "https://github.example.com"
+base_url: "https://github.example.com/api/v3"
 deployment_environment: "production"
 repository_sensor:
   event_type_whitelist:

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - git
   - scm
   - serverless
-version : 0.9.0
+version : 1.0.0
 python_versions:
   - "2"
   - "3"

--- a/sensors/github_repository_sensor.py
+++ b/sensors/github_repository_sensor.py
@@ -14,6 +14,10 @@ eventlet.monkey_patch(
 DATE_FORMAT_STRING = '%Y-%m-%d %H:%M:%S'
 
 
+# Default Github API url
+DEFAULT_API_URL = 'https://api.github.com'
+
+
 class GithubRepositorySensor(PollingSensor):
     def __init__(self, sensor_service, config=None, poll_interval=None):
         super(GithubRepositorySensor, self).__init__(sensor_service=sensor_service,
@@ -29,7 +33,12 @@ class GithubRepositorySensor(PollingSensor):
 
     def setup(self):
         # Empty string '' is not ok but None is fine. (Sigh)
-        config_base_url = self._config.get('base_url', None) or None
+        github_type = self._config.get('github_type', None)
+        if github_type == 'online':
+            config_base_url = DEFAULT_API_URL
+        else:
+            config_base_url = self._config.get('base_url', None) or None
+
         config_token = self._config.get('token', None) or None
         self._client = Github(config_token or None, base_url=config_base_url)
 

--- a/tests/fixtures/full-enterprise.yaml
+++ b/tests/fixtures/full-enterprise.yaml
@@ -1,4 +1,5 @@
-enterprise_url: "https://github.exmple.com/api/v3"
+web_url: "https://github.exmple.com"
+base_url: "https://github.exmple.com/api/v3"
 token: "foobar"
 
-default: "enterprise"
+github_type: "enterprise"

--- a/tests/fixtures/full.yaml
+++ b/tests/fixtures/full.yaml
@@ -1,6 +1,5 @@
-enterprise_url: "https://github.exmple.com/api/v3"
 token: "foobar"
 
-default: "online"
+github_type: "online"
 
 deployment_environment: "production"


### PR DESCRIPTION
The mismatch of `github_url` and `base_url` acturally breaks github enterprise support for those actions which do not use `_request`.

related issue: https://github.com/StackStorm-Exchange/stackstorm-github/issues/20