### PR TITLE
Use PyPi version of the package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
--e git+https://github.com/PyGithub/PyGithub#egg=PyGithub
+PyGithub==1.43.7
+urllib3
 #requests>=2.5.1,<2.6
 beautifulsoup4>=4.7.1,<4.8


### PR DESCRIPTION
This pull request updates pack to use PyPi version of the pack. It also adds missing ``urlib3`` dependency.