### PR TITLE
#38 - Sort githubs events by id before handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.1
+
+* Bug fix (#38) where the sensor assumes `event.id` coming from the GitHub api will be in numeric order.
+
 ## 2.0.0
 
 * Drop Python 2.7 support

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - git
   - scm
   - serverless
-version: 2.0.0
+version: 2.0.1
 python_versions:
   - "3"
 author : StackStorm, Inc.

--- a/sensors/github_repository_sensor.py
+++ b/sensors/github_repository_sensor.py
@@ -81,8 +81,8 @@ class GithubRepositorySensor(PollingSensor):
         # default value in this case rather than raise an exception.
         count = self._config['repository_sensor'].get('count', 30)
 
-        events = repository.get_events()[:count]
-        events = list(reversed(list(events)))
+        events = list(repository.get_events()[:count])
+        events.sort(key=lambda _event: _event.id, reverse=False)
 
         last_event_id = self._get_last_id(name=name)
 


### PR DESCRIPTION
Once the events are pulled from the API, deliberately sort the list by `event.id`