### PR TITLE
Check repository events before using.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1
+
+* Bug fix (#43) where the sensor will throw an exception if no events are returned from the GitHub api.
+
 ## 2.1.0
 
 * Add new ``github.create_pull`` action which allows user create Pull Requests for a branch.

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - git
   - scm
   - serverless
-version: 2.1.0
+version: 2.1.1
 python_versions:
   - "3"
 author : StackStorm, Inc.

--- a/sensors/github_repository_sensor.py
+++ b/sensors/github_repository_sensor.py
@@ -80,8 +80,10 @@ class GithubRepositorySensor(PollingSensor):
         # Assume a default value of 30. Better for the sensor to operate with some
         # default value in this case rather than raise an exception.
         count = self._config['repository_sensor'].get('count', 30)
+        repository_events = repository.get_events()
 
-        events = list(repository.get_events()[:count])
+        events = list(repository_events[:count]) \
+            if repository_events.totalCount > count else list(repository_events)
         events.sort(key=lambda _event: _event.id, reverse=False)
 
         last_event_id = self._get_last_id(name=name)


### PR DESCRIPTION
This PR adds a check to the sensor to validate the number of events returned is greater than the filter count before it attempts to slice the list.

Fixes #43 