### PR TITLE
Pack 2.1.2 - fix merge_pull action

### DIFF
--- a/actions/merge_pull.py
+++ b/actions/merge_pull.py
@@ -12,12 +12,29 @@ class MergePullAction(BaseGithubAction):
         repo = user.get_repo(repo)
         pull = repo.get_pull(pull_id)
 
-        if pull.mergeable:
-            return (False, 'Pull Request is not mergeable')
         if pull.merged:
-            return (False, 'Pull Request is already merged')
+            return False, 'Pull Request is already merged'
+        if not pull.mergeable:
+            return False, 'Pull Request is not mergeable'
 
         status = pull.merge()
 
         result = {'merged': status.merged, 'message': status.message}
         return result
+
+
+if __name__ == '__main__':
+    import os
+
+    GITHUB_TOKEN = os.environ.get('GITHUB_TOKEN')
+    GITHUB_ORG = os.environ.get('GITHUB_ORG')
+    GITHUB_REPO = os.environ.get('GITHUB_REPO')
+    GITHUB_BRANCH = os.environ.get('GITHUB_BRANCH')
+
+    PULL_ID = 13
+    act = MergePullAction(config={'token': GITHUB_TOKEN, 'github_type': 'online'})
+    res = act.run(user=GITHUB_ORG, repo=GITHUB_REPO, pull_id=PULL_ID)
+    import pprint
+
+    pp = pprint.PrettyPrinter(indent=4)
+    pp.pprint(res)

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - git
   - scm
   - serverless
-version: 2.1.0
+version: 2.1.2
 python_versions:
   - "3"
 author : StackStorm, Inc.


### PR DESCRIPTION
Based on github API documentation: https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
> The value of the mergeable attribute can be true, false, or null. If the value is null, then GitHub has started a background job to compute the mergeability. After giving the job time to complete, resubmit the request. When the job finishes, you will see a non-null value for the mergeable attribute in the response. If mergeable is true, then merge_commit_sha will be the SHA of the test merge commit.

The if condition to test if PR is mergeable was wrong. This PR is to fix it.