### PR TITLE
Update get_user.yaml default parameter for token

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.5
+
+* Fix default for token_user parameter in get_user action so that empty parameter has expected behavior.
+
 ## 2.1.4
 
 * Bug fix (#41) that `github.get_contents` action would be failed when decode parameter is set,

--- a/actions/get_user.yaml
+++ b/actions/get_user.yaml
@@ -12,7 +12,7 @@ parameters:
   token_user:
     type: "string"
     description: "The"
-    default: "{{action_context.api_user|default(None)}}"
+    default: "{{action_context.api_user|default()}}"
   github_type:
     type: "string"
     description: "The type of github installation to target, if unset will use the configured default."

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,7 +8,7 @@ keywords:
   - git
   - scm
   - serverless
-version: 2.1.4
+version: 2.1.5
 python_versions:
   - "3"
 author : StackStorm, Inc.


### PR DESCRIPTION
Closes https://github.com/StackStorm-Exchange/stackstorm-github/issues/54

When calling this action without a token_user and without an action_context.api_user, the default parameter specified is for some reason being evaluated into a string "None" instead of the None object. 

This causes the code block for "if token_user:" here: https://github.com/dalarsen/stackstorm-github/blob/master/actions/get_user.py#L12 to be evaluated as True and causes it to run the _change_to_user_token method to be run when it aught not be (in my organization, it leads to an unauthenticated request and causes it to crash, though I imagine this wouldn't universally be the consequence of this).